### PR TITLE
fix edge case for custom events with properties.id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,8 +73,11 @@ HubSpot.prototype.identify = function(identify) {
  */
 
 HubSpot.prototype.track = function(track) {
-  var props = track.properties();
-  props = convertDates(props);
+  // Hubspot expects properties.id to be the name of the .track() event
+  // Ref: http://developers.hubspot.com/docs/methods/enterprise_events/javascript_api
+  var props = convertDates(track.properties({ id: '_id' }));
+  props.id = track.event();
+
   push('trackEvent', track.event(), props);
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,12 +105,12 @@ describe('HubSpot', function() {
 
       it('should send an event', function() {
         analytics.track('event');
-        analytics.called(window._hsq.push, ['trackEvent', 'event', {}]);
+        analytics.called(window._hsq.push, ['trackEvent', 'event', { id: 'event' }]);
       });
 
       it('should send an event and properties', function() {
         analytics.track('event', { property: true });
-        analytics.called(window._hsq.push, ['trackEvent', 'event', { property: true }]);
+        analytics.called(window._hsq.push, ['trackEvent', 'event', { property: true, id: 'event' }]);
       });
 
       it('should convert dates to milliseconds', function() {
@@ -118,8 +118,20 @@ describe('HubSpot', function() {
         var ms = date.getTime();
 
         analytics.track('event', { date: date });
-        analytics.called(window._hsq.push, ['trackEvent', 'event', { date: ms }]);
+        analytics.called(window._hsq.push, ['trackEvent', 'event', { date: ms, id: 'event' }]);
       });
+
+      it('should attach track.event to properties.id', function() {
+        analytics.track('Viewed Product', {});
+        analytics.called(window._hsq.push, ['trackEvent', 'Viewed Product', { id: 'Viewed Product' }]);
+      });
+
+      it('should move properties.id to properties._id', function() {
+        analytics.track('Viewed Product', { id: '12345' });
+        analytics.called(window._hsq.push, ['trackEvent', 'Viewed Product', { id: 'Viewed Product', _id: '12345' }]);
+      });
+
+
     });
 
     describe('#page', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,8 +130,6 @@ describe('HubSpot', function() {
         analytics.track('Viewed Product', { id: '12345' });
         analytics.called(window._hsq.push, ['trackEvent', 'Viewed Product', { id: 'Viewed Product', _id: '12345' }]);
       });
-
-
     });
 
     describe('#page', function() {


### PR DESCRIPTION
https://segment.zendesk.com/agent/tickets/29707

Hubspot expects the `id` to be the name of the event. This was causing issues when people send `properties.id` because it was overwriting the event name. Mainly happens for eccomerce events such as Viewed Product. 

This changes the product id to be mapped as `_id` so that the semantic `id` can remain as the track event name. 

@ndhoule @bbeaird @sperand-io 