### PR TITLE
map revenue to `value` param

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ HubSpot.prototype.identify = function(identify) {
 HubSpot.prototype.track = function(track) {
   // Hubspot expects properties.id to be the name of the .track() event
   // Ref: http://developers.hubspot.com/docs/methods/enterprise_events/javascript_api
-  var props = convertDates(track.properties({ id: '_id' }));
+  var props = convertDates(track.properties({ id: '_id', revenue: 'value' }));
   props.id = track.event();
 
   push('trackEvent', track.event(), props);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,6 +130,11 @@ describe('HubSpot', function() {
         analytics.track('Viewed Product', { id: '12345' });
         analytics.called(window._hsq.push, ['trackEvent', 'Viewed Product', { id: 'Viewed Product', _id: '12345' }]);
       });
+
+      it('should send revenue as value', function() {
+        analytics.track('Did Something Valuable', { id: '12345', revenue: 13 });
+        analytics.called(window._hsq.push, ['trackEvent', 'Did Something Valuable', { id: 'Did Something Valuable', _id: '12345', value: 13 }]);
+      });
     });
 
     describe('#page', function() {


### PR DESCRIPTION
This maps `revenue` data to Hubspot to special key `value`, as shown here: http://developers.hubspot.com/docs/methods/enterprise_events/javascript_api

**Note**: This is already covered [on the server side](https://github.com/segmentio/integration-hubspot/blob/master/lib/mapper.js#L27) with the [`_m` parameter](http://developers.hubspot.com/docs/methods/enterprise_events/http_api).

@ndhoule