### PR TITLE
Add company and update it from `company.name`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+2.1.1 / 2017-09-26
+==================
+
+  * Populate Hubspot-reserved `company` from `traits.company.name`
 
 2.1.0 / 2017-03-16
 ==================

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,6 +65,11 @@ HubSpot.prototype.identify = function(identify) {
   var traits = identify.traits({ firstName: 'firstname', lastName: 'lastname' });
   traits = convertDates(traits);
   traits = formatTraits(traits);
+
+  if (identify.companyName() !== undefined) {
+    traits.company = identify.companyName();
+  }
+
   push('identify', traits);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hubspot",
   "description": "The Hubspot analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,6 +132,19 @@ describe('HubSpot', function() {
           gogurts_are_life: 'yolo'
         }]);
       });
+
+      it('should fill in company name', function() {
+        analytics.identify({
+          email: 'name@example.com',
+          company: {
+            name: 'Example Company'
+          }
+        });
+        analytics.called(window._hsq.push, ['identify', {
+          email: 'name@example.com',
+          company: 'Example Company'
+        }]);
+      });
     });
 
     describe('#track', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,13 +101,13 @@ describe('HubSpot', function() {
       it('should normalize name fields to firstname and lastname', function() {
         analytics.identify({
           email: 'name@example.com',
-          firstName: 'Rihanna',
-          lastName: 'Fenty'
+          firstName: 'First',
+          lastName: 'Last'
         });
         analytics.called(window._hsq.push, ['identify', {
           email: 'name@example.com',
-          firstname: 'Rihanna',
-          lastname: 'Fenty'
+          firstname: 'First',
+          lastname: 'Last'
         }]);
       });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,13 +101,13 @@ describe('HubSpot', function() {
       it('should normalize name fields to firstname and lastname', function() {
         analytics.identify({
           email: 'name@example.com',
-          firstName: 'First',
-          lastName: 'Last'
+          firstName: 'Rihanna',
+          lastName: 'Fenty'
         });
         analytics.called(window._hsq.push, ['identify', {
           email: 'name@example.com',
-          firstname: 'First',
-          lastname: 'Last'
+          firstname: 'Rihanna',
+          lastname: 'Fenty'
         }]);
       });
 


### PR DESCRIPTION
Uses the newly-specified `company.name` trait to populate the reserved Hubspot `company` property.

See: https://segment.atlassian.net/browse/PLATFORM-1221

cc @anoonan 