### PR TITLE
Add period conversion support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+2.1.3 / 2018-07-06
+==================
+  * Add support for tabs, carriage returns, new lines, vertical tabs, form feeds
+
 2.1.2 / 2017-09-28
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ function convertDates(properties) {
 function formatTraits(traits) {
   var ret = {};
   each(function(value, key) {
-    var k = key.toLowerCase().replace(/\s/g, '_');
+    var k = key.toLowerCase().replace(/\s+|\.+/g, '_');
     ret[k] = value;
   }, traits);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,7 +124,13 @@ function formatTraits(traits) {
   each(function(value, key) {
     // Using split/join due to IE 11 failing to properly support regex in str.replace()
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
-    var k = key.toLowerCase().split(' ').join('_').split('.').join('_');
+    var k = key.toLowerCase().split(' ').join('_') // spaces
+      .split('.').join('_') // Periods
+      .split('\n').join('_') // new lines
+      .split('\v').join('_') // Vertical tabs
+      .split('\t').join('_') // Regular tabs
+      .split('\f').join('_') // form feeds
+      .split('\r').join('_'); // Carriage returns
     ret[k] = value;
   }, traits);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,7 +124,8 @@ function formatTraits(traits) {
   each(function(value, key) {
     // Using split/join due to IE 11 failing to properly support regex in str.replace()
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
-    var k = key.toLowerCase().split(' ').join('_') // spaces
+    var k = key.toLowerCase()
+      .split(' ').join('_') // spaces
       .split('.').join('_') // Periods
       .split('\n').join('_') // new lines
       .split('\v').join('_') // Vertical tabs

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,9 @@ function convertDates(properties) {
 function formatTraits(traits) {
   var ret = {};
   each(function(value, key) {
-    var k = key.toLowerCase().replace(/\s+|\.+/g, '_');
+    // Using split/join due to IE 11 failing to properly support regex in str.replace()
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
+    var k = key.toLowerCase().split(' ').join('_').split('.').join('_');
     ret[k] = value;
   }, traits);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hubspot",
   "description": "The Hubspot analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.1.3-0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hubspot",
   "description": "The Hubspot analytics.js integration.",
-  "version": "2.1.3-0",
+  "version": "2.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -144,17 +144,6 @@ describe('HubSpot', function() {
         }]);
       });
 
-      it('should replace a mix of periods and spaces with _s', function() {
-        analytics.identify({
-          email: 'name@example.com',
-          'gogurts.are .. life': 'yolo'
-        });
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          gogurts_are____life: 'yolo'
-        }]);
-      });
-
       it('should fill in company name', function() {
         analytics.identify({
           email: 'name@example.com',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -122,14 +122,14 @@ describe('HubSpot', function() {
         }]);
       });
 
-      it('should replace spaces with _', function() {
+      it('should replace all spaces (tab, new lines, ect) with _', function() {
         analytics.identify({
           email: 'name@example.com',
-          'gogurts are life': 'yolo'
+          'gogurts are\tlife\rand\vgood\ntoday\fhorray': 'yolo'
         });
         analytics.called(window._hsq.push, ['identify', {
           email: 'name@example.com',
-          gogurts_are_life: 'yolo'
+          gogurts_are_life_and_good_today_horray: 'yolo'
         }]);
       });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -144,6 +144,17 @@ describe('HubSpot', function() {
         }]);
       });
 
+      it('should replace a mix of periods and spaces with _s', function() {
+        analytics.identify({
+          email: 'name@example.com',
+          'gogurts.are .. life': 'yolo'
+        });
+        analytics.called(window._hsq.push, ['identify', {
+          email: 'name@example.com',
+          gogurts_are____life: 'yolo'
+        }]);
+      });
+
       it('should fill in company name', function() {
         analytics.identify({
           email: 'name@example.com',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -133,6 +133,17 @@ describe('HubSpot', function() {
         }]);
       });
 
+      it('should replace periods with _', function() {
+        analytics.identify({
+          email: 'name@example.com',
+          'gogurts.are.life': 'yolo'
+        });
+        analytics.called(window._hsq.push, ['identify', {
+          email: 'name@example.com',
+          gogurts_are_life: 'yolo'
+        }]);
+      });
+
       it('should fill in company name', function() {
         analytics.identify({
           email: 'name@example.com',


### PR DESCRIPTION
**What does this PR do?**
Adds support for converting periods to underscores for properties and traits.


**Are there breaking changes in this PR?**
No


**Any background context you want to provide?**
JIRA with improvement request: https://segment.atlassian.net/browse/PLATFORM-2806


**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Testing has been done in the test fixtures, but not end-to-end yet.


**Is there parity with the server-side/android/iOS integration (if applicable)?**
Server-side: https://github.com/segmentio/integrations/pull/712


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**



**What are the relevant tickets?**
https://segment.atlassian.net/browse/PLATFORM-2806


**Helpful Docs**
